### PR TITLE
Fix silent failures on asset loads and swallowed exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "mss==9.0.1",
     "numpy==1.26.4",
     "opencv-python==4.9.0.80",
-    "opencv-python-headless==4.10.0.84",
     "packaging==24.2",
     "pillow==10.4.0",
     "pyautogui==0.9.54",

--- a/src/easymaple/common/cache.py
+++ b/src/easymaple/common/cache.py
@@ -1,8 +1,11 @@
 """Cache management for storing last loaded files."""
 
 import json
+import logging
 import os
 from src.easymaple.common import config
+
+log = logging.getLogger(__name__)
 
 
 CACHE_FILE = os.path.join(config.RESOURCES_DIR, '.cache.json')
@@ -26,8 +29,8 @@ def save_cache(cache_data):
         os.makedirs(config.RESOURCES_DIR, exist_ok=True)
         with open(CACHE_FILE, 'w') as f:
             json.dump(cache_data, f, indent=2)
-    except IOError:
-        pass  # Fail silently if can't save cache
+    except IOError as e:
+        log.warning("Failed to save cache: %s", e)
 
 
 def get_last_command_book():

--- a/src/easymaple/common/utils.py
+++ b/src/easymaple/common/utils.py
@@ -9,6 +9,14 @@ from src.easymaple.common import config, settings
 from random import random
 
 
+def load_image(path, flags=cv2.IMREAD_COLOR):
+    """Load an image from PATH, raising FileNotFoundError if it cannot be read."""
+    img = cv2.imread(path, flags)
+    if img is None:
+        raise FileNotFoundError(f"Asset not found or failed to load: '{path}'")
+    return img
+
+
 def run_if_enabled(function):
     """
     Decorator for functions that should only run if the bot is enabled.

--- a/src/easymaple/modules/bot.py
+++ b/src/easymaple/modules/bot.py
@@ -18,7 +18,7 @@ from src.easymaple.common.vkeys import press, key_down, key_up
 
 
 # The rune's buff icon
-RUNE_BUFF_TEMPLATE = cv2.imread('assets/rune_buff_template.jpg', 0)
+RUNE_BUFF_TEMPLATE = utils.load_image('assets/rune_buff_template.jpg', cv2.IMREAD_GRAYSCALE)
 
 
 class Bot(Configurable):

--- a/src/easymaple/modules/capture.py
+++ b/src/easymaple/modules/capture.py
@@ -28,14 +28,14 @@ WINDOWED_OFFSET_TOP = 36
 WINDOWED_OFFSET_LEFT = 10
 
 # The top-left and bottom-right corners of the minimap
-MM_TL_TEMPLATE = cv2.imread('assets/minimap_tl_template.png', 0)
-MM_BR_TEMPLATE = cv2.imread('assets/minimap_br_template.png', 0)
+MM_TL_TEMPLATE = utils.load_image('assets/minimap_tl_template.png', cv2.IMREAD_GRAYSCALE)
+MM_BR_TEMPLATE = utils.load_image('assets/minimap_br_template.png', cv2.IMREAD_GRAYSCALE)
 
 MMT_HEIGHT = max(MM_TL_TEMPLATE.shape[0], MM_BR_TEMPLATE.shape[0])
 MMT_WIDTH = max(MM_TL_TEMPLATE.shape[1], MM_BR_TEMPLATE.shape[1])
 
 # The player's symbol on the minimap
-PLAYER_TEMPLATE = cv2.imread('assets/player_template.png', 0)
+PLAYER_TEMPLATE = utils.load_image('assets/player_template.png', cv2.IMREAD_GRAYSCALE)
 PT_HEIGHT, PT_WIDTH = PLAYER_TEMPLATE.shape
 
 

--- a/src/easymaple/modules/notifier.py
+++ b/src/easymaple/modules/notifier.py
@@ -1,6 +1,7 @@
 """A module for detecting and notifying the user of dangerous in-game events."""
 
 from src.easymaple.common import config, utils
+import logging
 import time
 import os
 import cv2
@@ -12,6 +13,7 @@ import requests
 from dotenv import load_dotenv, find_dotenv
 from src.easymaple.routine.components import Point
 
+log = logging.getLogger(__name__)
 
 print(find_dotenv())
 load_dotenv()
@@ -20,37 +22,42 @@ load_dotenv()
 WEB_HOOK = os.environ.get("DISCORD_WEBHOOK", "")
 DISCORD_USER_ID = os.environ.get("DISCORD_USER_ID", "")
 
+if not WEB_HOOK:
+    log.warning("DISCORD_WEBHOOK is not set — Discord notifications will be disabled")
+
 print(f"Successfully loaded WEB_HOOK = {WEB_HOOK}, DISCORD_USER_ID={DISCORD_USER_ID}")
 
 def notify(message):
     """Sends a message to the Discord webhook."""
+    if not WEB_HOOK:
+        return
     try:
         requests.post(WEB_HOOK, json={"content": message})
-    except requests.RequestException:
-        pass
+    except requests.RequestException as e:
+        log.warning("Discord notification failed: %s", e)
 
 
 # A rune's symbol on the minimap
 RUNE_RANGES = (
     ((135, 50, 220), (200, 160, 255)),
 )
-rune_filtered = utils.filter_color(cv2.imread('assets/rune_template.png'), RUNE_RANGES)
+rune_filtered = utils.filter_color(utils.load_image('assets/rune_template.png'), RUNE_RANGES)
 RUNE_TEMPLATE = cv2.cvtColor(rune_filtered, cv2.COLOR_BGR2GRAY)
 
 # Other players' symbols on the minimap
 OTHER_RANGES = (
     ((0, 245, 215), (10, 255, 255)),
 )
-other_filtered = utils.filter_color(cv2.imread('assets/other_template.png'), OTHER_RANGES)
+other_filtered = utils.filter_color(utils.load_image('assets/other_template.png'), OTHER_RANGES)
 OTHER_TEMPLATE = cv2.cvtColor(other_filtered, cv2.COLOR_BGR2GRAY)
 
 # The Elite Boss's warning sign
-ELITE_TEMPLATE = cv2.imread('assets/elite_template.jpg', 0)
+ELITE_TEMPLATE = utils.load_image('assets/elite_template.jpg', cv2.IMREAD_GRAYSCALE)
 
-RUNE_COOLDOWN_TEMPLATE = cv2.imread('assets/rune_cd_template.jpg', 0)
-RUNE_COOLDOWN_TEMPLATE_1 = cv2.imread('assets/rune_cd_template_1.jpg', 0)
+RUNE_COOLDOWN_TEMPLATE = utils.load_image('assets/rune_cd_template.jpg', cv2.IMREAD_GRAYSCALE)
+RUNE_COOLDOWN_TEMPLATE_1 = utils.load_image('assets/rune_cd_template_1.jpg', cv2.IMREAD_GRAYSCALE)
 
-DEATH_TEMPLATE = cv2.imread('assets/death_template.png', 0)
+DEATH_TEMPLATE = utils.load_image('assets/death_template.png', cv2.IMREAD_GRAYSCALE)
 
 RUNE_DETECT_FREQUENCY = 40
 

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,6 @@ dependencies = [
     { name = "mss" },
     { name = "numpy" },
     { name = "opencv-python" },
-    { name = "opencv-python-headless" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyautogui" },
@@ -243,7 +242,6 @@ requires-dist = [
     { name = "mss", specifier = "==9.0.1" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "opencv-python", specifier = "==4.9.0.80" },
-    { name = "opencv-python-headless", specifier = "==4.10.0.84" },
     { name = "packaging", specifier = "==24.2" },
     { name = "pillow", specifier = "==10.4.0" },
     { name = "pyautogui", specifier = "==0.9.54" },
@@ -467,23 +465,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/64/7fdfb9386511cd6805451e012c537073a79a958a58795c4e602e538c388c/opencv_python-4.9.0.80-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4088cab82b66a3b37ffc452976b14a3c599269c247895ae9ceb4066d8188a57", size = 62208946, upload-time = "2023-12-31T13:34:00.941Z" },
     { url = "https://files.pythonhosted.org/packages/76/9e/db1c2d56c04b97981c06663384f45f28950a73d9acf840c4006d60d0a1ff/opencv_python-4.9.0.80-cp37-abi3-win32.whl", hash = "sha256:dcf000c36dd1651118a2462257e3a9e76db789a78432e1f303c7bac54f63ef6c", size = 28546907, upload-time = "2023-12-31T13:34:03.922Z" },
     { url = "https://files.pythonhosted.org/packages/c7/ec/9dabb6a9abfdebb3c45b0cc52dec901caafef2b2c7e7d6a839ed86d81e91/opencv_python-4.9.0.80-cp37-abi3-win_amd64.whl", hash = "sha256:3f16f08e02b2a2da44259c7cc712e779eff1dd8b55fdb0323e8cab09548086c0", size = 38624911, upload-time = "2023-12-31T13:34:09.481Z" },
-]
-
-[[package]]
-name = "opencv-python-headless"
-version = "4.10.0.84"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/7e/d20f68a5f1487adf19d74378d349932a386b1ece3be9be9915e5986db468/opencv-python-headless-4.10.0.84.tar.gz", hash = "sha256:f2017c6101d7c2ef8d7bc3b414c37ff7f54d64413a1847d89970b6b7069b4e1a", size = 95117755, upload-time = "2024-06-17T18:32:15.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/9b/583c8d9259f6fc19413f83fd18dd8e6cbc8eefb0b4dc6da52dd151fe3272/opencv_python_headless-4.10.0.84-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:a4f4bcb07d8f8a7704d9c8564c224c8b064c63f430e95b61ac0bffaa374d330e", size = 54835657, upload-time = "2024-06-18T04:58:12.904Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/7b/b4c67f5dad7a9a61c47f7a39e4050e8a4628bd64b3c3daaeb755d759f928/opencv_python_headless-4.10.0.84-cp37-abi3-macosx_12_0_x86_64.whl", hash = "sha256:5ae454ebac0eb0a0b932e3406370aaf4212e6a3fdb5038cc86c7aea15a6851da", size = 56475470, upload-time = "2024-06-17T19:34:39.604Z" },
-    { url = "https://files.pythonhosted.org/packages/91/61/f838ce2046f3ec3591ea59ea3549085e399525d3b4558c4ed60b55ed88c0/opencv_python_headless-4.10.0.84-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46071015ff9ab40fccd8a163da0ee14ce9846349f06c6c8c0f2870856ffa45db", size = 29329705, upload-time = "2024-06-17T20:00:49.406Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/09/248f86a404567303cdf120e4a301f389b68e3b18e5c0cc428de327da609c/opencv_python_headless-4.10.0.84-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:377d08a7e48a1405b5e84afcbe4798464ce7ee17081c1c23619c8b398ff18295", size = 49858781, upload-time = "2024-06-17T18:31:49.495Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c0/66f88d58500e990a9a0a5c06f98862edf1d0a3a430781218a8c193948438/opencv_python_headless-4.10.0.84-cp37-abi3-win32.whl", hash = "sha256:9092404b65458ed87ce932f613ffbb1106ed2c843577501e5768912360fc50ec", size = 28675298, upload-time = "2024-06-17T18:28:56.897Z" },
-    { url = "https://files.pythonhosted.org/packages/26/d0/22f68eb23eea053a31655960f133c0be9726c6a881547e6e9e7e2a946c4f/opencv_python_headless-4.10.0.84-cp37-abi3-win_amd64.whl", hash = "sha256:afcf28bd1209dd58810d33defb622b325d3cbe49dcd7a43a902982c33e5fad05", size = 38754031, upload-time = "2024-06-17T18:29:04.871Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add utils.load_image() that raises FileNotFoundError instead of returning None; all cv2.imread() calls at module level now use it, so a missing asset causes a clear startup error instead of an AttributeError deep in the bot loop
- Replace bare `pass` in cache.save_cache and notifier.notify with logging.warning so I/O failures and Discord errors are surfaced
- Guard notify() early-return when DISCORD_WEBHOOK is unset and log a warning at import time instead of silently sending to empty URL
- Remove opencv-python-headless (conflicts with opencv-python on a GUI host; headless is for servers without a display)