### PR TITLE
Optimize Discord notifications and capture window handling

### DIFF
--- a/src/easymaple/modules/capture.py
+++ b/src/easymaple/modules/capture.py
@@ -74,27 +74,37 @@ class Capture:
         print('\n[~] Started video capture')
         self.thread.start()
 
+    def _find_game_window(self):
+        """Returns a pygetwindow object for the game window, or None if not found."""
+        for title in gw.getAllTitles():
+            if ("Remote Desktop Connection" in title or "远程桌面协议" in title
+                    or "Maplestory" in title or " - Moonlight" in title):
+                windows = gw.getWindowsWithTitle(title)
+                if windows:
+                    return windows[0]
+        return None
+
     def _main(self):
         """Constantly monitors the player's position and in-game events."""
+        window_obj = None
         while True:
-            # Calibrate screen capture
-            all_titles = gw.getAllTitles()
-            window_name = None
-            for title in all_titles:
-                if ("Remote Desktop Connection" in title or "远程桌面协议" in title or "Maplestory" in title
-                        or " - Moonlight" in title):
-                    window_name = title
-            if window_name is None:
-                continue
-
-            window_obj = gw.getWindowsWithTitle(window_name)[0]
+            # Only search for the game window when we don't already have a handle
+            if window_obj is None:
+                window_obj = self._find_game_window()
+                if window_obj is None:
+                    time.sleep(0.5)
+                    continue
 
             self.ready = True
 
-            self.window['left'] = window_obj.left
-            self.window['top'] = window_obj.top
-            self.window['width'] = window_obj.width
-            self.window['height'] = window_obj.height
+            try:
+                self.window['left'] = window_obj.left
+                self.window['top'] = window_obj.top
+                self.window['width'] = window_obj.width
+                self.window['height'] = window_obj.height
+            except Exception:
+                window_obj = None
+                continue
 
             # Calibrate by finding the bottom right corner of the minimap
             with mss.mss() as self.sct:
@@ -103,8 +113,12 @@ class Capture:
             if self.frame is None:
                 continue
 
-            tl, _ = utils.single_match(self.frame, MM_TL_TEMPLATE)
-            _, br = utils.single_match(self.frame, MM_BR_TEMPLATE)
+            gray_frame = cv2.cvtColor(self.frame, cv2.COLOR_BGR2GRAY)
+            result_tl = cv2.matchTemplate(gray_frame, MM_TL_TEMPLATE, cv2.TM_CCOEFF_NORMED)
+            _, _, _, tl = cv2.minMaxLoc(result_tl)
+            result_br = cv2.matchTemplate(gray_frame, MM_BR_TEMPLATE, cv2.TM_CCOEFF_NORMED)
+            _, _, _, br_tl = cv2.minMaxLoc(result_br)
+            br = (br_tl[0] + MM_BR_TEMPLATE.shape[1], br_tl[1] + MM_BR_TEMPLATE.shape[0])
             mm_tl = (
                 tl[0] + 2,
                 tl[1] + 2

--- a/src/easymaple/modules/notifier.py
+++ b/src/easymaple/modules/notifier.py
@@ -6,6 +6,7 @@ import time
 import os
 import cv2
 import pygame
+import queue
 import threading
 import numpy as np
 import keyboard as kb
@@ -27,14 +28,6 @@ if not WEB_HOOK:
 
 print(f"Successfully loaded WEB_HOOK = {WEB_HOOK}, DISCORD_USER_ID={DISCORD_USER_ID}")
 
-def notify(message):
-    """Sends a message to the Discord webhook."""
-    if not WEB_HOOK:
-        return
-    try:
-        requests.post(WEB_HOOK, json={"content": message})
-    except requests.RequestException as e:
-        log.warning("Discord notification failed: %s", e)
 
 
 # A rune's symbol on the minimap
@@ -84,15 +77,17 @@ class Notifier:
         self.rune_alert_delay = 10
 
         self.rune_counter = 0
-        self.rune_warning_thread = None
-
         self.death_counter = 0
-        self.rune_notifying = False
+
+        self._discord_queue = queue.Queue()
+        self._rune_notify_event = threading.Event()
 
     def start(self):
         """Starts this Notifier's thread."""
 
         print('\n[~] Started notifier')
+        threading.Thread(target=self._discord_sender, daemon=True).start()
+        threading.Thread(target=self._rune_discord_loop, daemon=True).start()
         self.thread.start()
 
     def _main(self):
@@ -109,7 +104,7 @@ class Notifier:
                 gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
                 if np.count_nonzero(gray < 15) / height / width > self.room_change_threshold:
                     for _ in range(5):
-                        notify(f"<@{DISCORD_USER_ID}> 白屋了兄弟")
+                        self._enqueue_notify(f"<@{DISCORD_USER_ID}> 白屋了兄弟")
                     self._alert('siren')
 
                 # Check for elite warning
@@ -138,10 +133,8 @@ class Notifier:
                         if time.time() - report_time > 10 or report_time == 0:
                             self._ping("rune_appeared", volume=0.75)
                             report_time = time.time()
-                        if not self.rune_notifying:
-                            self.rune_notifying = True
-                            t = threading.Thread(target=self._rune_discord_loop, daemon=True)
-                            t.start()
+                        if not self._rune_notify_event.is_set():
+                            self._rune_notify_event.set()
 
                 if self.death_counter >= DEATH_DETECT_FREQUENCY or self.death_counter == 0:
                     self.death_counter = 1
@@ -177,19 +170,29 @@ class Notifier:
         self.mixer.set_volume(volume)
         self.mixer.play()
 
-    def _rune_discord_loop(self):
-        """
-        Sends bursts of 3 Discord notifications for rune detection.
-        Repeats every 30 seconds until the rune is resolved.
-        """
+    def _enqueue_notify(self, message):
+        if WEB_HOOK:
+            self._discord_queue.put(message)
 
-        try:
+    def _discord_sender(self):
+        """Persistent worker that drains _discord_queue and posts to Discord."""
+        while True:
+            message = self._discord_queue.get()
+            try:
+                requests.post(WEB_HOOK, json={"content": message})
+            except requests.RequestException as e:
+                log.warning("Discord notification failed: %s", e)
+            finally:
+                self._discord_queue.task_done()
+
+    def _rune_discord_loop(self):
+        """Persistent worker: wakes on _rune_notify_event, notifies Discord every 30s until rune clears."""
+        while True:
+            self._rune_notify_event.wait()
             while config.bot.rune_active:
-                notify(f"<@{DISCORD_USER_ID}> 符文出现了，快去解！")
-                # Wait 30s
+                self._enqueue_notify(f"<@{DISCORD_USER_ID}> 符文出现了，快去解！")
                 time.sleep(30)
-        finally:
-            self.rune_notifying = False
+            self._rune_notify_event.clear()
 
 
 #################################


### PR DESCRIPTION
- Replace synchronous requests.post with a queue-backed sender thread so Discord I/O never blocks the detection loop
- Replace per-rune threading.Thread spawns with a persistent worker thread that sleeps on a threading.Event, eliminating repeated thread creation
- Cache the game window handle in capture._main; only re-search when the handle is None or raises (window closed), avoiding getAllTitles on every calibration cycle
- Fold two single_match calls (each doing cvtColor) into one grayscale conversion + two direct matchTemplate calls during minimap calibration